### PR TITLE
Fixes unicodeDecodeError and ValueError

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -37,9 +37,13 @@ class Executor:
             return True
 
     def test_target(self, url):
-        parsed_url = urlparse(url)
-        host = parsed_url.netloc
-        path = parsed_url.path
+        try:
+            parsed_url = urlparse(url)
+            host = parsed_url.netloc
+            path = parsed_url.path
+        except ValueError as e:
+            self.logger.error(f"An error occured during connectivity test for '{url}': {e}. Skipping...")
+            return
 
         # first, check if we can even perform a normal request
         # otherwise, we might confuse general non-responsiveness with a vulnerability
@@ -110,12 +114,18 @@ class Executor:
         for url in self.urls:
             url = url.strip()
 
-            if not urlparse(url).scheme:
-                # looks like the user supplied a hostname instead of a URL
-                # no worries, we just add an https scheme
-                url = f"https://{url}"
+            try:
+                if not urlparse(url).scheme:
+                    # looks like the user supplied a hostname instead of a URL
+                    # no worries, we just add an https scheme
+                    url = f"https://{url}"
+            
+            except ValueError as e:
+                self.logger.error(f"An error occured during urlparse for '{url}': {e}. Skipping...")
+                continue
 
             self.test_target(url)
+            
         
         self.logger.info(f"Execution completed at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}.")
 

--- a/core/executor.py
+++ b/core/executor.py
@@ -42,7 +42,7 @@ class Executor:
             host = parsed_url.netloc
             path = parsed_url.path
         except ValueError as e:
-            self.logger.error(f"An error occured during connectivity test for '{url}': {e}. Skipping...")
+            self.logger.error(f"An error occurred during URL parsing of '{url}': {e}. Skipping...")
             return
 
         # first, check if we can even perform a normal request
@@ -121,7 +121,7 @@ class Executor:
                     url = f"https://{url}"
             
             except ValueError as e:
-                self.logger.error(f"An error occured during urlparse for '{url}': {e}. Skipping...")
+                self.logger.error(f"An error occurred during URL parsing of '{url}': {e}. Skipping...")
                 continue
 
             self.test_target(url)

--- a/smugchunks.py
+++ b/smugchunks.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     args = parse_args()
 
     try:
-        urls = args.url or open(args.input_file).readlines()
+        urls = args.url or open(args.input_file, encoding="utf-8", errors="replace").readlines()
     except OSError as e:
         print(f"Invalid input file: {e.__class__.__name__}")
         exit()


### PR DESCRIPTION
Nice tool, I like that a lot!
When used with a large list, unicode chars might be encountered that will run in errors such as 

```
Traceback (most recent call last):
  File "/home/user/tools/smugchunks/smugchunks.py", line 35, in <module>
    urls = args.url or open(args.input_file).readlines()
  File "/usr/lib/python3.10/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf6 in position 2228: invalid start byte
```
The following code replaces bad chars to make the tool continue properly.

Also I encountered several ValueErrors that should now be handled properly.